### PR TITLE
Fix: Update the title

### DIFF
--- a/components/templates/waiting-list.tsx
+++ b/components/templates/waiting-list.tsx
@@ -9,7 +9,7 @@ export default function WaitingList() {
         <div className='mx-auto max-w-2xl text-center'>
           <Badge className='px-3 py-1 text-sm font-medium'>Join the Waitlist</Badge>
           <h2 className='mt-4 text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl'>
-            Be the first to experience our platform
+            Be the first to experience our platform!
           </h2>
           <p className='mt-4 text-muted-foreground'>
             Sign up for our waitlist and be the first to access our cutting-edge features and innovative solutions.


### PR DESCRIPTION
This PR updates the title in the WaitingList component from 'Be the first to experience our platform' to 'Be the first to experience our platform!' as per the feature request. The change is minor and ensures consistency with the intended messaging. The update has been tested to ensure it renders correctly without any errors.

Closes #1

**Automated fix by GitHub Micro-Agent**

### Changes Made:
- Locate the text 'Be the first to experience our platform' in the components/templates/waiting-list.tsx file.
- Update the text to 'Be the first to experience our platform!' as specified in the issue.
- Ensure the change is consistent with the repository's coding patterns and architecture.

### Testing:
Run the Next.js development server using 'npm run dev' or 'pnpm dev'. Navigate to the landing page and verify that the text 'Be the first to experience our platform!' is displayed correctly in the WaitingList component. Ensure there are no console errors and the page renders as expected.